### PR TITLE
Rural Amethyst Tapir - All ETH can be stolen during rebalancing for mTOFTs that hold native #69

### DIFF
--- a/contracts/interfaces/external/stargate/IStargateRouter.sol
+++ b/contracts/interfaces/external/stargate/IStargateRouter.sol
@@ -38,6 +38,12 @@ interface IStargateRouterBase {
         bytes dstNativeAddr;
     }
 
+    //for StargateComposer
+    struct SwapAmount {
+        uint256 amountLD; // the amount, in Local Decimals, to be swapped
+        uint256 minAmountLD; // the minimum amount accepted out on destination
+    }
+
     function swap(
         uint16 _dstChainId,
         uint256 _srcPoolId,
@@ -52,13 +58,14 @@ interface IStargateRouterBase {
 }
 
 interface IStargateRouter is IStargateRouterBase {
-    //for RouterETH
-    function swapETH(
-        uint16 _dstChainId, // _refundAddressdestination Stargate chainId
-        address payable, // refund additional messageFee to this address
-        bytes calldata _toAddress, // the receiver of the destination ETH
-        uint256 _amountLD, // the amount, in Local Decimals, to be swapped
-        uint256 _minAmountLD // the minimum amount accepted out on destination
+    //for StargateComposer
+    function swapETHAndCall(
+        uint16 _dstChainId, // destination Stargate chainId
+        address payable _refundAddress, // refund additional messageFee to this address
+        bytes calldata _to, // the receiver of the destination ETH
+        SwapAmount memory _swapAmount, // the amount and the minimum swap amount
+        lzTxObj memory _lzTxParams, // the LZ tx params
+        bytes calldata _payload // the payload to send to the destination
     ) external payable;
 
     function bridge() external view returns (IStargateBridge); // for StargateRouter contract


### PR DESCRIPTION
### TL;DR

Updates swapETH to swapETHAndCall, and introduces SwapAmount struct in StargateRouter interface.

### What changed?

Changed swapETH function to swapETHAndCall in IStargateRouter. This function now takes a new struct SwapAmount, which specifies the amount to be swapped and the minimum swap amount, and the LZ tx params, along with a payload to send to the destination, replacing individual parameters in the old swapETH function. Also added SwapAmount struct to IStargateRouterBase.
