### PR TITLE
Rural Amethyst Tapir - Stargate Pools conversion rate leads to token accumulation inside the Balancer contract #71

### DIFF
--- a/contracts/interfaces/external/stargate/IStargateRouter.sol
+++ b/contracts/interfaces/external/stargate/IStargateRouter.sol
@@ -19,6 +19,8 @@ import {ILayerZeroEndpoint} from "../../../layerzero/v1/interfaces/ILayerZeroEnd
 
 interface IStargatePool {
     function convertRate() external view returns (uint256);
+    function localDecimals() external view returns (uint256);
+    function sharedDecimals() external view returns (uint256);
 }
 
 interface IStargateFactory {

--- a/contracts/interfaces/external/stargate/IStargateRouter.sol
+++ b/contracts/interfaces/external/stargate/IStargateRouter.sol
@@ -16,6 +16,15 @@ import {ILayerZeroEndpoint} from "../../../layerzero/v1/interfaces/ILayerZeroEnd
 
 // Tapioca
 
+
+interface IStargatePool {
+    function convertRate() external view returns (uint256);
+}
+
+interface IStargateFactory {
+    function getPool(uint256 _poolId) external view returns (address);
+}
+
 interface IStargateBridge {
     function quoteLayerZeroFee(
         uint16 _chainId,


### PR DESCRIPTION
This PR introduces `IStargatePool` and `IStargateFactory` interfaces to `IStargateRouter`. `IStargatePool` includes methods to determine conversion rates and cliff durations for local and shared pools. `IStargateFactory` adds a method to retrieve specific pool addresses using the pool ID. This addition aligns with recent conventions and taps into the continuous efforts to modularize the Stargate system. To test this change, use contracts that interact with `IStargateRouter` and ensure they can now access and interact with pool conversion rates and share cliff durations, and retrieve specific pool addresses.