### PR TITLE
deadrosez | [L-02] BaseLeverageExecutor does not verify that the actually swapped amount is the same as amountIn

### DIFF
--- a/contracts/interfaces/bar/ILeverageExecutor.sol
+++ b/contracts/interfaces/bar/ILeverageExecutor.sol
@@ -19,11 +19,11 @@ interface ILeverageExecutor {
 
     function yieldBox() external view returns (address);
 
-    function getCollateral(address assetAddress, address collateralAddress, uint256 assetAmountIn, bytes calldata data)
+    function getCollateral(address refundDustAddress, address assetAddress, address collateralAddress, uint256 assetAmountIn, bytes calldata data)
         external
         returns (uint256 collateralAmountOut); //used for buyCollateral
 
-    function getAsset(address collateralAddress, address assetAddress, uint256 collateralAmountIn, bytes calldata data)
+    function getAsset(address refundDustAddress, address collateralAddress, address assetAddress, uint256 collateralAmountIn, bytes calldata data)
         external
         returns (uint256 assetAmountOut); //used for sellCollateral
 }


### PR DESCRIPTION
patch(`ZeroXSwapper`): refund dust to sender if `amountIn` was not used entirely [`86dth3q0e`]
- Check swapped amount and refund if dust is left in the contract

`GT_CU-86dth3q0e-zerox-swapper-refund`