### PR TITLE
deadrosez | [L-02] BaseLeverageExecutor does not verify that the actually swapped amount is the same as amountIn

### DIFF
--- a/contracts/Swapper/ZeroXSwapper.sol
+++ b/contracts/Swapper/ZeroXSwapper.sol
@@ -31,8 +31,6 @@ contract ZeroXSwapper is IZeroXSwapper, Ownable {
     address public zeroXProxy;
     ICluster public cluster;
 
-    bool public isOneInchEnabled;
-
     /// **************
     /// *** ERRORS ***
     /// **************
@@ -56,7 +54,7 @@ contract ZeroXSwapper is IZeroXSwapper, Ownable {
 
     /// @notice swaps a token for another, using 0x as a swap aggregator
     /// @dev All of the parameters below are provided by the API response.
-    /// @param swapData the swap data. Either 0x or 1inch
+    /// @param swapData the swap data. 0x
     /// @param amountIn the amount of sellToken to sell
     /// @param minAmountOut the minimum amount of buyToken bought
     /// @return amountOut the amount of buyToken bought
@@ -69,10 +67,6 @@ contract ZeroXSwapper is IZeroXSwapper, Ownable {
 
         // Transfer tokens to this contract
         swapData.sellToken.safeTransferFrom(msg.sender, address(this), amountIn);
-
-        if (!isOneInchEnabled && swapData.swapTarget != zeroXProxy) {
-            revert InvalidProxy(swapData.swapTarget, zeroXProxy);
-        }
 
         uint256 amountInBefore = swapData.sellToken.balanceOf(address(this));
         // Approve the 0x proxy to spend the sell token, and call the swap function
@@ -97,11 +91,6 @@ contract ZeroXSwapper is IZeroXSwapper, Ownable {
 
         // Transfer the bought tokens to the sender
         swapData.buyToken.safeTransfer(msg.sender, amountOut);
-    }
-
-    /// @notice updates the swap function to use 1inch instead of 0x.
-    function setIsOneInchEnabled(bool _isOneInchEnabled) external onlyOwner {
-        isOneInchEnabled = _isOneInchEnabled;
     }
 
     /**

--- a/test/ZeroXSwapper/ZeroXSwapper.t.sol
+++ b/test/ZeroXSwapper/ZeroXSwapper.t.sol
@@ -72,16 +72,6 @@ contract ZeroXSwapperTest is TestBase, StdAssertions, StdCheats, StdUtils, TestH
         assertEq(swapper.owner(), address(this));
     }
 
-    function test_0x_1inch_enable() public {
-        bool status = swapper.isOneInchEnabled();
-        assertFalse(status);
-
-        swapper.setIsOneInchEnabled(true);
-
-        status = swapper.isOneInchEnabled();
-        assertTrue(status);
-    }
-
     function test_0x_swap() public {
         uint256 amount = 1 ether;
 


### PR DESCRIPTION
patch(0x Swapper): removed 1inch fallback from 0x Swapper [86dtgzrat]
- Removed 1inch support from ZeroXSwapper.sol file as it will be implemented as an internal contract if needed

`GT_CU-86dtgzrat-remove-1inch-0x-swapper`