### PR TITLE
deadrosez | [M-04] MagnetarOptionModule uses wrong TapiocaOptionLiquidityProvision interface #18 & deadrosez | [M-01] Magnetar.sol sends funds from/to msg.sender instead of data.user #15 `CU-86dtjd3k8` & `CU-86dtjd3ku`

### DIFF
--- a/contracts/Magnetar/modules/MagnetarOptionModule.sol
+++ b/contracts/Magnetar/modules/MagnetarOptionModule.sol
@@ -346,7 +346,8 @@ contract MagnetarOptionModule is MagnetarBaseModule {
             tOLPId, data.externalData.singularity
         );
 
-        // transfer unlocked position to the user in case owner is `address(this)`
+        // in case owner is `address(this)`
+        //    transfer unlocked position to the user
         if (ownerOfTOLP == address(this)) {
             IYieldBox _yieldBox = IYieldBox(ITapiocaOptionLiquidityProvision(data.removeAndRepayData.unlockData.target).yieldBox());
             _yieldBox.transfer(address(this), data.user, sglAssetId, ybShares);

--- a/contracts/Magnetar/modules/MagnetarOptionModule.sol
+++ b/contracts/Magnetar/modules/MagnetarOptionModule.sol
@@ -339,8 +339,17 @@ contract MagnetarOptionModule is MagnetarBaseModule {
         address ownerOfTOLP = IERC721(data.removeAndRepayData.unlockData.target).ownerOf(tOLPId);
         if (ownerOfTOLP != data.user && ownerOfTOLP != address(this)) revert Magnetar_ActionParamsMismatch();
 
+        (uint128 sglAssetId, uint128 ybShares,,) = ITapiocaOptionLiquidityProvision(data.removeAndRepayData.unlockData.target).lockPositions(tOLPId);
+
+        // will be sent to `data.user` or `address(this)`
         ITapiocaOptionLiquidityProvision(data.removeAndRepayData.unlockData.target).unlock(
-            tOLPId, data.externalData.singularity, data.user
+            tOLPId, data.externalData.singularity
         );
+
+        // transfer unlocked position to the user in case owner is `address(this)`
+        if (ownerOfTOLP == address(this)) {
+            IYieldBox _yieldBox = IYieldBox(ITapiocaOptionLiquidityProvision(data.removeAndRepayData.unlockData.target).yieldBox());
+            _yieldBox.transfer(address(this), data.user, sglAssetId, ybShares);
+        }
     }
 }

--- a/contracts/interfaces/tap-token/ITapiocaOptionLiquidityProvision.sol
+++ b/contracts/interfaces/tap-token/ITapiocaOptionLiquidityProvision.sol
@@ -25,7 +25,9 @@ interface ITapiocaOptionLiquidityProvision is IERC721 {
         external
         returns (uint256 tokenId);
 
-    function unlock(uint256 tokenId, address singularity, address to) external returns (uint256 sharesOut);
+    function unlock(uint256 tokenId, address singularity) external returns (uint256 sharesOut);
+
+    function lockPositions(uint256 tokenId) external view returns(uint128 sglAssetID, uint128 ybShares, uint128 lockTime, uint128 lockDuration);
 }
 
 struct IOptionsLockData {


### PR DESCRIPTION
patch(`tOLP unlock params`): Update `MagnetarOptionModule._unlock` with latest tOLP params [`86dtjd3ku`]

- `user` param doesn't exist anymore in `tOLP` -> updated the interface and _unlock method code
- in case owner of `tOLPId` is `Magnetar`, perform a `yieldBox.transfer(sglAssetId, ybShares)` back to `data.user`

chore: git issue test