### PR TITLE
Remove the `Pearlmit` code from `TOE::transferFrom()` `CU-86dtj04d9`

### DIFF
--- a/contracts/tapiocaOmnichainEngine/BaseTapiocaOmnichainEngine.sol
+++ b/contracts/tapiocaOmnichainEngine/BaseTapiocaOmnichainEngine.sol
@@ -63,30 +63,6 @@ abstract contract BaseTapiocaOmnichainEngine is OFT, PearlmitHandler, BaseToeMsg
     }
 
     /**
-     * @inheritdoc IERC20
-     * @dev Extended the capabilities to check allowance and transfer on Pearlmit.
-     */
-    function transferFrom(address from, address to, uint256 value) public virtual override returns (bool) {
-        address spender = _msgSender();
-        // If allowance on this contract is not met, check the Pearlmit allowance.
-        if (allowance(from, spender) < value) {
-            bool isApproved = isERC20Approved(from, to, address(this), value);
-            if (!isApproved) revert BaseTapiocaOmnichainEngine_PearlmitNotApproved();
-
-            // Used to let YieldBox transfer tokens without implementing Pearlmit in the YieldBox.
-            // _transfer(from, to, value);
-            bool isErr = pearlmit.transferFromERC20(from, to, address(this), value);
-            if (isErr) revert BaseTapiocaOmnichainEngine_PearlmitFailed();
-        } else {
-            // If allowance on this contract is met, perform a normal transferFrom.
-            _spendAllowance(from, spender, value);
-            _transfer(from, to, value);
-        }
-
-        return true;
-    }
-
-    /**
      * @inheritdoc OAppSender
      * @dev Overwrite to check for < values.
      */

--- a/test/mocks/ToeTokenMock/ToeTokenMock.sol
+++ b/test/mocks/ToeTokenMock/ToeTokenMock.sol
@@ -46,14 +46,6 @@ contract ToeTokenMock is BaseTapiocaOmnichainEngine, ModuleManager, ERC20Permit 
         _setModule(uint8(Module.ToeTokenReceiver), _receiverModule);
     }
 
-    function transferFrom(address from, address to, uint256 value)
-        public
-        override(BaseTapiocaOmnichainEngine, ERC20)
-        returns (bool)
-    {
-        return BaseTapiocaOmnichainEngine.transferFrom(from, to, value);
-    }
-
     function getTypedDataHash(ERC20PermitStruct calldata _permitData) public view returns (bytes32) {
         bytes32 permitTypeHash_ =
             keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");


### PR DESCRIPTION
fix(`BaseTOE`): Removed `transferFrom()` override to not use `Pearlmit` anymore [`86dtj04d9`]