### PR TITLE
0xAdrii | [HIGH-01] - Tapioca omnichain extender flow allows performing delegatecalls to arbitrary addresses #1 [`CU-86dtjja7x`]

### DIFF
--- a/contracts/tapiocaOmnichainEngine/extension/TapiocaOmnichainExtExec.sol
+++ b/contracts/tapiocaOmnichainEngine/extension/TapiocaOmnichainExtExec.sol
@@ -52,6 +52,7 @@ contract TapiocaOmnichainExtExec {
 
         uint256 approvalsLength = approvals.length;
         for (uint256 i = 0; i < approvalsLength;) {
+            _sanitizeTarget(approvals[i].token);
             try IERC20Permit(approvals[i].token).permit(
                 approvals[i].owner,
                 approvals[i].spender,
@@ -77,6 +78,7 @@ contract TapiocaOmnichainExtExec {
 
         uint256 approvalsLength = approvals.length;
         for (uint256 i = 0; i < approvalsLength;) {
+            _sanitizeTarget(approvals[i].token);
             try ERC721Permit(approvals[i].token).permit(
                 approvals[i].spender,
                 approvals[i].tokenId,
@@ -98,6 +100,8 @@ contract TapiocaOmnichainExtExec {
     function pearlmitApproval(address _srcChainSender, bytes memory _data) public {
         (address pearlmit, IPearlmit.PermitBatchTransferFrom memory batchApprovals) =
             TapiocaOmnichainEngineCodec.decodePearlmitBatchApprovalMsg(_data);
+        
+        _sanitizeTarget(pearlmit);
 
         batchApprovals.owner = _srcChainSender; // overwrite the owner with the src chain sender
         // Redundant security measure, just for the sake of it

--- a/test/Magnetar/Magnetar.t.sol
+++ b/test/Magnetar/Magnetar.t.sol
@@ -1194,6 +1194,7 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         ERC20Mock paymentToken = new ERC20Mock();
         TapiocaOptionsBrokerMock tOb = new TapiocaOptionsBrokerMock(address(oTAP), address(tapOft), IPearlmit(address(pearlmit)));
 
+
         cluster.updateContract(0, address(tOb), true);
         cluster.updateContract(0, address(tapOft), true);
         cluster.updateContract(0, address(paymentToken), true);


### PR DESCRIPTION
- sanitized `erc20PermitApproval` target
- sanitized `erc721PermitApproval` target
- sanitized `pearlmitApproval` target
- some tests fixes