### PR TITLE
make `DEFAULT_STALE_PERIOD` on `ChainlinkUtils` settable `CU-86dtjph9u`

### DIFF
--- a/contracts/oracle/utils/ChainlinkUtils.sol
+++ b/contracts/oracle/utils/ChainlinkUtils.sol
@@ -16,14 +16,14 @@ abstract contract ChainlinkUtils is AccessControlDefaultAdminRules {
     /// @notice Represent the maximum amount of time (in seconds) between each Chainlink update
     /// before the price feed is considered stale
     mapping(AggregatorV3Interface => uint32) public stalePeriods;
-    uint32 private constant DEFAULT_STALE_PERIOD = 86400;
+    uint32 public DEFAULT_STALE_PERIOD = 86400;
 
     // Role for guardians and governors
     bytes32 public constant GUARDIAN_ROLE_CHAINLINK = keccak256("GUARDIAN_ROLE");
 
     error InvalidChainlinkRate();
     error StalePeriodNotValid();
-    
+
     event StalePeriodUpdated(AggregatorV3Interface indexed feed, uint32 indexed val);
 
     /// @notice Reads a Chainlink feed. Perform a sequence upbeat check if L2 chain
@@ -32,8 +32,8 @@ abstract contract ChainlinkUtils is AccessControlDefaultAdminRules {
     function _readChainlinkBase(AggregatorV3Interface feed, uint256 castedRatio) internal view returns (uint256) {
         if (castedRatio == 0) {
             uint256 _stalePeriod = stalePeriods[feed];
-            if(_stalePeriod == 0) _stalePeriod = DEFAULT_STALE_PERIOD;
-            
+            if (_stalePeriod == 0) _stalePeriod = DEFAULT_STALE_PERIOD;
+
             (, int256 ratio,, uint256 updatedAt,) = feed.latestRoundData();
 
             if (
@@ -77,11 +77,19 @@ abstract contract ChainlinkUtils is AccessControlDefaultAdminRules {
     /// @notice Updates stale period for feed
     /// @param _feed the feed key
     /// @param _stalePeriod the new sale period
-    function updateStalePeriod(AggregatorV3Interface _feed, uint32 _stalePeriod) external  onlyRole(GUARDIAN_ROLE_CHAINLINK) {
+    function updateStalePeriod(AggregatorV3Interface _feed, uint32 _stalePeriod)
+        external
+        onlyRole(GUARDIAN_ROLE_CHAINLINK)
+    {
         if (_stalePeriod == 0) revert StalePeriodNotValid();
 
         stalePeriods[_feed] = _stalePeriod;
         emit StalePeriodUpdated(_feed, _stalePeriod);
     }
 
+    /// @notice Changes the Stale Period
+    /// @param _stalePeriod New stale period (in seconds)
+    function changeDefaultStalePeriod(uint32 _stalePeriod) external onlyRole(GUARDIAN_ROLE_CHAINLINK) {
+        DEFAULT_STALE_PERIOD = _stalePeriod;
+    }
 }


### PR DESCRIPTION
patch(`ChainlinkUtils`): Made `DEFAULT_STALE_PERIOD` public + settable [`86dtjph9u`]
- `DEFAULT_STALE_PERIOD` is now public
- New `changeDefaultStalePeriod()`