### PR TITLE
0xAdrii | [H-06] - Compose messages will wrongly hardcode source chain sender as Magnetar `CU-86dtb8rra`

### DIFF
--- a/contracts/interfaces/periph/ITapiocaOmnichainEngine.sol
+++ b/contracts/interfaces/periph/ITapiocaOmnichainEngine.sol
@@ -47,6 +47,11 @@ interface ITapiocaOmnichainEngine {
         payable
         returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt);
 
+    function sendPacketFrom(address _from, LZSendParam calldata _lzSendParam, bytes calldata _composeMsg)
+        external
+        payable
+        returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt);
+
     function getTypedDataHash(ERC20PermitStruct calldata _permitData) external view returns (bytes32);
 
     function quoteSendPacket(


### PR DESCRIPTION
- New `BaseTOE::encode()` which uses the same `OFTMsgCodec` logic in addition to a `_from`
- Adapted `BaseTOE::_buildOFTMsgAndOptions()` take a new `_from` param
- Adapted `BaseTOE::quoteSendPacket()` to use `_buildOFTMsgAndOptions()`
- Adapted `TOESender::sendPacket()` to use `_buildOFTMsgAndOptions()`
- New `TOESender::sendPacketFrom()`