### PR TITLE
Pearlmit post PermitC change update `CU-86dtm14xr`

### DIFF
--- a/contracts/Cluster/Cluster.sol
+++ b/contracts/Cluster/Cluster.sol
@@ -31,7 +31,7 @@ contract Cluster is Ownable, ICluster {
     mapping(uint32 lzChainId => mapping(address _contract => bool status)) private _whitelisted;
 
     /// @notice Centralized role assignment for Tapioca contract. Other contracts can use this mapping to check if an address has a role on them
-    mapping(address _contract => mapping(bytes32 role => mapping(address target => bool hasRole))) public hasRole;
+    mapping(address _contract => mapping(bytes32 role => bool hasRole)) public hasRole;
 
     /// @notice event emitted when LZ chain id is updated
     event LzChainUpdate(uint256 indexed _oldChain, uint256 indexed _newChain);
@@ -40,7 +40,7 @@ contract Cluster is Ownable, ICluster {
         address indexed _contract, uint32 indexed _lzChainId, bool indexed _oldStatus, bool _newStatus
     );
     /// @notice event emitted when a role is set
-    event RoleSet(address indexed _contract, bytes32 indexed _role, address indexed _target, bool _hasRole);
+    event RoleSet(address indexed _contract, bytes32 indexed _role, bool _hasRole);
 
     // ************** //
     // *** ERRORS *** //
@@ -117,15 +117,11 @@ contract Cluster is Ownable, ICluster {
      * @notice sets a role for a contract.
      * @param _contract the contract's address.
      * @param _role the role's name for the contract, in bytes32 format.
-     * @param _target the address to set the role for.
      * @param _hasRole the new role status.
      */
-    function setRoleForContract(address _contract, bytes32 _role, address _target, bool _hasRole)
-        external
-        isAuthorized
-    {
-        hasRole[_contract][_role][_target] = _hasRole;
-        emit RoleSet(_contract, _role, _target, _hasRole);
+    function setRoleForContract(address _contract, bytes32 _role, bool _hasRole) external isAuthorized {
+        hasRole[_contract][_role] = _hasRole;
+        emit RoleSet(_contract, _role, _hasRole);
     }
 
     // ********************* //

--- a/contracts/Magnetar/Magnetar.sol
+++ b/contracts/Magnetar/Magnetar.sol
@@ -278,7 +278,8 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
 
         if (funcSig == ITapiocaOmnichainEngine.sendPacket.selector) {
             selectorValidated = true;
-            (address from_, LZSendParam memory lzSendParam_,) = abi.decode(_actionCalldata[4:], (address,LZSendParam, bytes));
+            (address from_, LZSendParam memory lzSendParam_,) =
+                abi.decode(_actionCalldata[4:], (address, LZSendParam, bytes));
             address owner_ = OFTMsgCodec.bytes32ToAddress(lzSendParam_.sendParam.to);
             _checkSender(owner_);
             _checkSender(from_);
@@ -399,7 +400,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
                     }
                 }
 
-                pearlmit.approve(yieldBox, assetId, _target, amount, block.timestamp.toUint48());
+                pearlmit.approve(1155, yieldBox, assetId, _target, amount, block.timestamp.toUint48());
                 IYieldBox(yieldBox).setApprovalForAll(address(pearlmit), true);
                 _executeCall(_target, _actionCalldata, _actionValue);
                 IYieldBox(yieldBox).setApprovalForAll(address(pearlmit), false);
@@ -420,7 +421,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
                     }
                 }
 
-                pearlmit.approve(tOLP, tokenId, _target, 1, block.timestamp.toUint48());
+                pearlmit.approve(721, tOLP, tokenId, _target, 1, block.timestamp.toUint48());
                 ITapiocaOptionLiquidityProvision(tOLP).setApprovalForAll(address(pearlmit), true);
                 (bytes memory tokenIdData) = _executeCall(_target, _actionCalldata, _actionValue);
                 ITapiocaOptionLiquidityProvision(tOLP).setApprovalForAll(address(pearlmit), false);
@@ -445,7 +446,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
                     }
                 }
 
-                pearlmit.approve(tapOFT, 0, _target, amount.toUint200(), block.timestamp.toUint48());
+                pearlmit.approve(20, tapOFT, 0, _target, amount.toUint200(), block.timestamp.toUint48());
 
                 tapOFT.safeApprove(address(pearlmit), type(uint256).max);
                 _executeCall(_target, _actionCalldata, _actionValue);
@@ -552,7 +553,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
             uint256 tapAmountBefore = IERC20(tapToken).balanceOf(address(this));
 
             // execute
-            pearlmit.approve(_paymentToken, 0, _target, eligibleTapAmount.toUint200(), block.timestamp.toUint48());
+            pearlmit.approve(20, _paymentToken, 0, _target, eligibleTapAmount.toUint200(), block.timestamp.toUint48());
             _paymentToken.safeApprove(address(pearlmit), eligibleTapAmount);
             _executeCall(_target, _actionCalldata, _actionValue);
             _paymentToken.safeApprove(address(pearlmit), 0);
@@ -561,7 +562,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
             {
                 address oTap = ITapiocaOptionBroker(_target).oTAP();
                 address oTapOwner = IERC721(oTap).ownerOf(_oTAPTokenID);
-                pearlmit.clearAllowance(oTapOwner, oTap, _oTAPTokenID);
+                pearlmit.clearAllowance(oTapOwner, 721, oTap, _oTAPTokenID);
             }
 
             uint256 tapAmountAfter = IERC20(tapToken).balanceOf(address(this));

--- a/contracts/Magnetar/modules/MagnetarBaseModule.sol
+++ b/contracts/Magnetar/modules/MagnetarBaseModule.sol
@@ -74,7 +74,7 @@ abstract contract MagnetarBaseModule is MagnetarStorage {
     }
 
     function _pearlmitApprove(address _yieldBox, uint256 _tokenId, address _market, uint256 _amount) internal {
-        pearlmit.approve(_yieldBox, _tokenId, _market, _amount.toUint200(), block.timestamp.toUint48());
+        pearlmit.approve(1155, _yieldBox, _tokenId, _market, _amount.toUint200(), block.timestamp.toUint48());
     }
 
     function _extractTokens(address _from, address _token, uint256 _amount) internal returns (uint256) {

--- a/contracts/Magnetar/modules/MagnetarMintModule.sol
+++ b/contracts/Magnetar/modules/MagnetarMintModule.sol
@@ -254,7 +254,9 @@ contract MagnetarMintModule is MagnetarBaseModule {
         bool isErr = pearlmit.transferFromERC721(data.user, address(this), data.lockData.target, tOLPTokenId);
         if (isErr) revert Magnetar_ExtractTokenFail();
 
-        pearlmit.approve(data.lockData.target, tOLPTokenId, data.participateData.target, 1, block.timestamp.toUint48());
+        pearlmit.approve(
+            721, data.lockData.target, tOLPTokenId, data.participateData.target, 1, block.timestamp.toUint48()
+        );
         IERC721(data.lockData.target).approve(address(pearlmit), tOLPTokenId);
         uint256 oTAPTokenId = ITapiocaOptionBroker(data.participateData.target).participate(tOLPTokenId);
 

--- a/contracts/Magnetar/modules/MagnetarOptionModule.sol
+++ b/contracts/Magnetar/modules/MagnetarOptionModule.sol
@@ -101,7 +101,12 @@ contract MagnetarOptionModule is MagnetarBaseModule {
         _depositToYb(_yieldBox, address(this), tOLPSglAssetId, _fraction);
 
         pearlmit.approve(
-            address(_yieldBox), tOLPSglAssetId, data.lockData.target, data.lockData.amount, block.timestamp.toUint48()
+            1155,
+            address(_yieldBox),
+            tOLPSglAssetId,
+            data.lockData.target,
+            data.lockData.amount,
+            block.timestamp.toUint48()
         );
         _yieldBox.setApprovalForAll(address(pearlmit), true);
 
@@ -133,7 +138,9 @@ contract MagnetarOptionModule is MagnetarBaseModule {
             if (isErr) revert Magnetar_ExtractTokenFail();
         }
 
-        pearlmit.approve(data.lockData.target, tOLPTokenId, data.participateData.target, 1, block.timestamp.toUint48());
+        pearlmit.approve(
+            721, data.lockData.target, tOLPTokenId, data.participateData.target, 1, block.timestamp.toUint48()
+        );
         IERC721(data.lockData.target).approve(address(pearlmit), tOLPTokenId);
         uint256 oTAPTokenId = ITapiocaOptionBroker(data.participateData.target).participate(tOLPTokenId);
 

--- a/contracts/interfaces/periph/ICluster.sol
+++ b/contracts/interfaces/periph/ICluster.sol
@@ -21,5 +21,5 @@ interface ICluster {
 
     function lzChainId() external view returns (uint32);
 
-    function hasRole(address _contract, bytes32 _role, address _target) external view returns (bool);
+    function hasRole(address _contract, bytes32 _role) external view returns (bool);
 }

--- a/contracts/interfaces/periph/IPearlmit.sol
+++ b/contracts/interfaces/periph/IPearlmit.sol
@@ -13,15 +13,8 @@ pragma solidity 0.8.22;
 */
 
 interface IPearlmit {
-    enum TokenType {
-        ERC20, // 0
-        ERC721, // 1
-        ERC1155 // 2
-
-    }
-
     struct SignatureApproval {
-        uint8 tokenType; // 0 = ERC20, 1 = ERC721, 2 = ERC1155.
+        uint256 tokenType; // 20 = ERC20, 721 = ERC721, 1155 = ERC1155.
         address token; // Address of the token.
         uint256 id; // ID of the token (0 if ERC20).
         uint200 amount; // Amount of the token (0 if ERC721).
@@ -39,14 +32,15 @@ interface IPearlmit {
         bytes32 hashedData; // Hashed data that comes with the permit execution. See more in Pearlmit.sol.
     }
 
-    function approve(address token, uint256 id, address operator, uint200 amount, uint48 expiration) external;
+    function approve(uint256 tokenType, address token, uint256 id, address operator, uint200 amount, uint48 expiration)
+        external;
 
-    function allowance(address owner, address operator, address token, uint256 id)
+    function allowance(address owner, address operator, uint256 tokenType, address token, uint256 id)
         external
         view
         returns (uint256 allowedAmount, uint256 expiration);
 
-    function clearAllowance(address owner, address token, uint256 id) external;
+    function clearAllowance(address owner, uint256 tokenType, address token, uint256 id) external;
 
     function permitBatchTransferFrom(PermitBatchTransferFrom calldata batch, bytes32 hashedData)
         external

--- a/contracts/interfaces/periph/IPearlmit.sol
+++ b/contracts/interfaces/periph/IPearlmit.sol
@@ -26,7 +26,8 @@ interface IPearlmit {
         address owner; // Address of the owner of the tokens.
         uint256 nonce; // Nonce of the owner.
         uint48 sigDeadline; // Deadline for the signature.
-        bytes signedPermit; // Signature of the permit.
+        uint256 masterNonce; // Master nonce of the owner.
+        bytes signedPermit; // Signature of the permit. (Not present in the TYPEHASH)
         address executor; // Address of the allowed executor of the permit.
         // In the case of Tapioca, it'll be the `msg.sender` from src chain, checked against `TOE` trusted `srcChainSender`.
         bytes32 hashedData; // Hashed data that comes with the permit execution. See more in Pearlmit.sol.

--- a/contracts/pearlmit/Pearlmit.sol
+++ b/contracts/pearlmit/Pearlmit.sol
@@ -47,7 +47,7 @@ contract Pearlmit is PermitC {
      *
      * @param batch PermitBatchTransferFrom struct containing all necessary data for batch transfer.
      * batch.approvals - array of SignatureApproval structs.
-     *      * batch.approvals.tokenType - type of token (0 = ERC20, 1 = ERC721, 2 = ERC1155).
+     *      * batch.approvals.tokenType - type of token (20 = ERC20, 721 = ERC721, 1155 = ERC1155).
      *      * batch.approvals.token - address of the token.
      *      * batch.approvals.id - id of the token (0 if ERC20).
      *      * batch.approvals.amount - amount of the token (0 if ERC721).

--- a/contracts/pearlmit/Pearlmit.sol
+++ b/contracts/pearlmit/Pearlmit.sol
@@ -87,17 +87,6 @@ contract Pearlmit is PermitC {
     }
 
     /**
-     * @notice After transfer of all operation should clear the allowance of the operator.
-     */
-    function _afterTransferFrom(address token, address owner, address to, uint256 id, uint256 amount)
-        internal
-        override
-        returns (bool isError)
-    {
-        _clearAllowance(owner, token, msg.sender, id, ZERO_BYTES32);
-    }
-
-    /**
      * @dev Clear the allowance of an owner to a given operator by setting the amount to 0 and expiring it.
      */
     function _clearAllowance(address owner, address token, address operator, uint256 id, bytes32 orderId) internal {

--- a/contracts/pearlmit/PearlmitHandler.sol
+++ b/contracts/pearlmit/PearlmitHandler.sol
@@ -31,7 +31,7 @@ abstract contract PearlmitHandler is Ownable {
 
     /// @notice Perform an allowance check for an ERC721 token on Pearlmit.
     function isERC721Approved(address owner, address spender, address token, uint256 id) internal view returns (bool) {
-        (uint256 allowedAmount,) = pearlmit.allowance(owner, spender, token, id); // Returns 0 if not approved or expired
+        (uint256 allowedAmount,) = pearlmit.allowance(owner, spender, 721, token, id); // Returns 0 if not approved or expired
         return allowedAmount > 0;
     }
 
@@ -41,7 +41,7 @@ abstract contract PearlmitHandler is Ownable {
         view
         returns (bool)
     {
-        (uint256 allowedAmount,) = pearlmit.allowance(owner, spender, token, 0); // Returns 0 if not approved or expired
+        (uint256 allowedAmount,) = pearlmit.allowance(owner, spender, 20, token, 0); // Returns 0 if not approved or expired
         return allowedAmount >= amount;
     }
 

--- a/contracts/pearlmit/PearlmitHash.sol
+++ b/contracts/pearlmit/PearlmitHash.sol
@@ -20,8 +20,9 @@ library PearlmitHash {
     bytes32 public constant _PERMIT_SIGNATURE_APPROVAL_TYPEHASH =
         keccak256("SignatureApproval(uint256 tokenType,address token,uint256 id,uint200 amount,address operator)");
 
+    // Only `signedPermit` is not present, otherwise should be 1:1 with `IPearlmit.PermitBatchTransferFrom`
     bytes32 public constant _PERMIT_BATCH_TRANSFER_FROM_TYPEHASH = keccak256(
-        "PermitBatchTransferFrom(SignatureApproval[] approvals,uint256 nonce,uint48 sigDeadline,uint256 masterNonce,address executor,bytes32 hashedData)SignatureApproval(uint256 tokenType,address token,uint256 id,uint200 amount,address operator)"
+        "PermitBatchTransferFrom(SignatureApproval[] approvals,address owner,uint256 nonce,uint48 sigDeadline,uint256 masterNonce,address executor,bytes32 hashedData)SignatureApproval(uint256 tokenType,address token,uint256 id,uint200 amount,address operator)"
     );
 
     /**

--- a/contracts/pearlmit/PearlmitHash.sol
+++ b/contracts/pearlmit/PearlmitHash.sol
@@ -44,6 +44,7 @@ library PearlmitHash {
             abi.encode(
                 _PERMIT_BATCH_TRANSFER_FROM_TYPEHASH,
                 keccak256(abi.encodePacked(permitHashes)),
+                batch.owner,
                 batch.nonce,
                 batch.sigDeadline,
                 masterNonce,

--- a/contracts/pearlmit/PearlmitHash.sol
+++ b/contracts/pearlmit/PearlmitHash.sol
@@ -17,13 +17,12 @@ import {IPearlmit} from "tapioca-periph/interfaces/periph/IPearlmit.sol";
 
 library PearlmitHash {
     // Batch transfer
-    // keccak256("SignatureApproval(uint8 tokenType,address token,uint256 id,uint200 amount,address operator)")
     bytes32 public constant _PERMIT_SIGNATURE_APPROVAL_TYPEHASH =
-        0x9907ae0a8b239bb7feef50f64ab23ff79fe790ab79bf66ed21a188dbd846e268;
+        keccak256("SignatureApproval(uint256 tokenType,address token,uint256 id,uint200 amount,address operator)");
 
-    // keccak256("PermitBatchTransferFrom(SignatureApproval[] approvals,uint256 nonce,uint48 sigDeadline,uint256 masterNonce,address executor,bytes32 hashedData)SignatureApproval(address token,uint256 id,uint200 amount,address operator)")
-    bytes32 public constant _PERMIT_BATCH_TRANSFER_FROM_TYPEHASH =
-        0xd5d7a259ad9503199f90b7ab0f3666a023407b882a97e7cbb0ca90a4169f0bf8;
+    bytes32 public constant _PERMIT_BATCH_TRANSFER_FROM_TYPEHASH = keccak256(
+        "PermitBatchTransferFrom(SignatureApproval[] approvals,uint256 nonce,uint48 sigDeadline,uint256 masterNonce,address executor,bytes32 hashedData)SignatureApproval(uint256 tokenType,address token,uint256 id,uint200 amount,address operator)"
+    );
 
     /**
      * @dev Hashes the permit batch transfer from.

--- a/contracts/tapiocaOmnichainEngine/TapiocaOmnichainSender.sol
+++ b/contracts/tapiocaOmnichainEngine/TapiocaOmnichainSender.sol
@@ -97,7 +97,7 @@ abstract contract TapiocaOmnichainSender is BaseTapiocaOmnichainEngine {
         // Verify caller is either address(this) or has Cluster TOE role
         if (_from != address(0)) {
             ICluster cluster = getCluster();
-            if (!cluster.hasRole(msg.sender, keccak256("TOE"), address(this))) {
+            if (!cluster.hasRole(msg.sender, keccak256("TOE"))) {
                 revert TapiocaOmnichainSender__ClusterRoleNotApproved();
             }
         }

--- a/test/Magnetar/Magnetar.t.sol
+++ b/test/Magnetar/Magnetar.t.sol
@@ -148,7 +148,7 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         collateral = new ERC20Mock();
 
         cluster = new Cluster(aEid, address(this));
-        pearlmit = new Pearlmit("Test", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
 
         TapiocaOmnichainEngineHelper toeHelper = new TapiocaOmnichainEngineHelper();
         MagnetarCollateralModule collateralModule =
@@ -375,7 +375,7 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
             yieldBox.setApprovalForAll(address(magnetar), true);
 
             // lend approvals
-            pearlmit.approve(address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+            pearlmit.approve(1155, address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
             yieldBox.setApprovalForAll(address(pearlmit), true);
             sgl.approve(address(magnetar), type(uint256).max);
         }
@@ -434,16 +434,18 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
             yieldBox.setApprovalForAll(address(pearlmit), true);
 
             // lend approvals
-            pearlmit.approve(address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+            pearlmit.approve(1155, address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
             sgl.approve(address(magnetar), type(uint256).max);
 
             // collateral approvals
-            pearlmit.approve(address(yieldBox), collateralId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+            pearlmit.approve(
+                1155, address(yieldBox), collateralId, address(sgl), type(uint200).max, uint48(block.timestamp)
+            ); // Atomic approval
             sgl.approve(address(magnetar), type(uint256).max);
 
             // market operations approvals
-            pearlmit.approve(address(asset), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-            pearlmit.approve(address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+            pearlmit.approve(20, address(asset), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+            pearlmit.approve(20, address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
             sgl.approve(address(magnetar), type(uint256).max);
             sgl.approveBorrow(address(magnetar), type(uint256).max);
         }
@@ -546,7 +548,7 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
                 call: repayData
             });
 
-            pearlmit.approve(address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+            pearlmit.approve(1155, address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
             sgl.approve(address(magnetar), type(uint256).max);
 
             magnetar.burst(calls);
@@ -570,14 +572,16 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         uint256 tokenAmount_ = 1 ether;
         uint256 borrowAmount_ = 1e17;
 
-        pearlmit.approve(address(asset), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(collateral), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(asset), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(collateral), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
 
-        pearlmit.approve(address(asset), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(asset), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
 
-        pearlmit.approve(address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(yieldBox), collateralId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(1155, address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(
+            1155, address(yieldBox), collateralId, address(sgl), type(uint200).max, uint48(block.timestamp)
+        ); // Atomic approval
 
         yieldBox.setApprovalForAll(address(pearlmit), true);
 
@@ -710,14 +714,16 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         uint256 tokenAmount_ = 1 ether;
         uint256 borrowAmount_ = 1e17;
 
-        pearlmit.approve(address(asset), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(collateral), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(asset), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(collateral), 0, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
 
-        pearlmit.approve(address(asset), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(asset), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
 
-        pearlmit.approve(address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(yieldBox), collateralId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(1155, address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(
+            1155, address(yieldBox), collateralId, address(sgl), type(uint200).max, uint48(block.timestamp)
+        ); // Atomic approval
 
         yieldBox.setApprovalForAll(address(pearlmit), true);
 
@@ -861,9 +867,11 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         {
             MagnetarCall[] memory magnetarCalls = new MagnetarCall[](2);
 
-            pearlmit.approve(address(yieldBox), collateralId, address(bb), type(uint200).max, uint48(block.timestamp)); // Atomic approval
             pearlmit.approve(
-                address(yieldBox), collateralId, address(magnetar), type(uint200).max, uint48(block.timestamp)
+                1155, address(yieldBox), collateralId, address(bb), type(uint200).max, uint48(block.timestamp)
+            ); // Atomic approval
+            pearlmit.approve(
+                1155, address(yieldBox), collateralId, address(magnetar), type(uint200).max, uint48(block.timestamp)
             ); // Atomic approval
             collateral.approve(address(magnetar), type(uint256).max);
             yieldBox.setApprovalForAll(address(pearlmit), true);
@@ -913,8 +921,8 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         uint256 tokenAmount_ = 1 ether;
         uint256 mintAmount_ = 1e17;
 
-        pearlmit.approve(address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(yieldBox), collateralId, address(bb), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(1155, address(yieldBox), collateralId, address(bb), type(uint200).max, uint48(block.timestamp)); // Atomic approval
         yieldBox.setApprovalForAll(address(magnetar), true);
         yieldBox.setApprovalForAll(address(pearlmit), true);
         bb.approveBorrow(address(magnetar), type(uint256).max);
@@ -978,8 +986,8 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
         uint256 tokenAmount_ = 1 ether;
         uint256 mintAmount_ = 1e17;
 
-        pearlmit.approve(address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
-        pearlmit.approve(address(yieldBox), collateralId, address(bb), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(20, address(collateral), 0, address(magnetar), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(1155, address(yieldBox), collateralId, address(bb), type(uint200).max, uint48(block.timestamp)); // Atomic approval
         yieldBox.setApprovalForAll(address(magnetar), true);
         yieldBox.setApprovalForAll(address(pearlmit), true);
         bb.approveBorrow(address(magnetar), type(uint256).max);
@@ -1115,7 +1123,7 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
 
         // lend approvals
         sgl.approve(address(magnetar), type(uint256).max);
-        pearlmit.approve(address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
+        pearlmit.approve(1155, address(yieldBox), assetId, address(sgl), type(uint200).max, uint48(block.timestamp)); // Atomic approval
         yieldBox.setApprovalForAll(address(pearlmit), true);
 
         //yb deposit approvals
@@ -1198,7 +1206,7 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
 
         deal(address(paymentToken), address(this), 1 ether);
 
-        pearlmit.approve(address(paymentToken), 0, address(magnetar), uint200(1 ether), uint48(block.timestamp));
+        pearlmit.approve(20, address(paymentToken), 0, address(magnetar), uint200(1 ether), uint48(block.timestamp));
         paymentToken.approve(address(pearlmit), 1 ether);
 
         MagnetarCall[] memory calls = new MagnetarCall[](1);

--- a/test/Magnetar/modules/MagnetarTestHelper.sol
+++ b/test/Magnetar/modules/MagnetarTestHelper.sol
@@ -729,6 +729,7 @@ contract MagnetarTestHelper is TestHelper {
             nonce: 0,
             sigDeadline: uint48(data._deadline), //deadline
             signedPermit: signedPermit,
+            masterNonce: pearlmit.masterNonce(data._owner),
             executor: data._owner,
             hashedData: hashedData
         });

--- a/test/Magnetar/modules/MagnetarTestHelper.sol
+++ b/test/Magnetar/modules/MagnetarTestHelper.sol
@@ -186,7 +186,7 @@ contract MagnetarTestHelper is TestHelper {
 
         clusterA = new Cluster(aEid, address(this));
         clusterB = new Cluster(bEid, address(this));
-        pearlmit = new Pearlmit("Test", "1");
+        pearlmit = new Pearlmit("Test", "1", address(this), 0);
 
         magnetarA = createMagnetar(address(clusterA), address(pearlmit));
         magnetarB = createMagnetar(address(clusterB), address(pearlmit));
@@ -619,7 +619,7 @@ contract MagnetarTestHelper is TestHelper {
         _asset.approve(address(pearlmit), type(uint256).max);
         _setYieldBoxApproval(yieldBox, address(_sgl));
         _setYieldBoxApproval(yieldBox, address(pearlmit));
-        pearlmit.approve(address(yieldBox), _assetId, address(_sgl), type(uint200).max, uint48(block.timestamp));
+        pearlmit.approve(1155, address(yieldBox), _assetId, address(_sgl), type(uint200).max, uint48(block.timestamp));
 
         uint256 share = yieldBox.toShare(_assetId, amount, false);
         yieldBox.depositAsset(_assetId, address(this), address(this), 0, share);
@@ -634,7 +634,9 @@ contract MagnetarTestHelper is TestHelper {
         _collateral.approve(address(pearlmit), type(uint256).max);
         _setYieldBoxApproval(yieldBox, address(_sgl));
         _setYieldBoxApproval(yieldBox, address(pearlmit));
-        pearlmit.approve(address(yieldBox), _collateralId, address(_sgl), type(uint200).max, uint48(block.timestamp));
+        pearlmit.approve(
+            1155, address(yieldBox), _collateralId, address(_sgl), type(uint200).max, uint48(block.timestamp)
+        );
 
         uint256 share = yieldBox.toShare(_collateralId, amount, false);
         yieldBox.depositAsset(_collateralId, address(this), address(this), 0, share);
@@ -654,7 +656,7 @@ contract MagnetarTestHelper is TestHelper {
     }
 
     function repay(uint256 part, uint256 _assetId, Singularity _sgl) public {
-        pearlmit.approve(address(yieldBox), _assetId, address(_sgl), type(uint200).max, uint48(block.timestamp));
+        pearlmit.approve(1155, address(yieldBox), _assetId, address(_sgl), type(uint200).max, uint48(block.timestamp));
         (Module[] memory modules, bytes[] memory calls) = marketHelper.repay(address(this), address(this), false, part);
         _sgl.execute(modules, calls, true);
     }
@@ -744,7 +746,7 @@ contract MagnetarTestHelper is TestHelper {
         IPearlmit.SignatureApproval[] memory signatureApprovals = new IPearlmit.SignatureApproval[](1);
 
         signatureApprovals[0] = IPearlmit.SignatureApproval({
-            tokenType: uint8(IPearlmit.TokenType.ERC20),
+            tokenType: 20,
             token: _asset,
             id: _id,
             amount: uint200(_amount),

--- a/test/pearlmit/Pearlmit.t.sol
+++ b/test/pearlmit/Pearlmit.t.sol
@@ -60,6 +60,7 @@ contract PearlmitTest is PearlmitBaseTest {
                 owner: alice,
                 nonce: nonce,
                 sigDeadline: uint48(sigDeadline),
+                masterNonce: pearlmit.masterNonce(alice),
                 signedPermit: signedPermit,
                 executor: executor,
                 hashedData: hashedData

--- a/test/pearlmit/Pearlmit.t.sol
+++ b/test/pearlmit/Pearlmit.t.sol
@@ -8,4 +8,98 @@ import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 import {Pearlmit, IPearlmit, PearlmitHash} from "tapioca-periph/pearlmit/Pearlmit.sol";
 import {PearlmitBaseTest, ERC20Mock, ERC721Mock, ERC1155Mock} from "./PearlmitBase.t.sol";
 
-contract PearlmitTest is PearlmitBaseTest {}
+contract PearlmitTest is PearlmitBaseTest {
+    function test_hashBatchTransferFrom() public {
+        address erc20Addr = _deployNew20(alice, 1000);
+
+        {
+            uint256 nonce = 0; // Can be random, it's unordered
+            uint48 sigDeadline = uint48(block.timestamp);
+            address executor = alice; // Who is expected execute the permit
+            bytes32 hashedData = keccak256("0x"); // Extra data
+
+            // Create approvals + their hashes
+            IPearlmit.SignatureApproval[] memory approvals = new IPearlmit.SignatureApproval[](1);
+            approvals[0] =
+                IPearlmit.SignatureApproval({tokenType: 20, token: erc20Addr, id: 0, amount: 100, operator: bob});
+            bytes32[] memory hashApprovals = new bytes32[](1);
+            for (uint256 i = 0; i < 1; ++i) {
+                hashApprovals[i] = keccak256(
+                    abi.encode(
+                        PearlmitHash._PERMIT_SIGNATURE_APPROVAL_TYPEHASH,
+                        approvals[i].tokenType,
+                        approvals[i].token,
+                        approvals[i].id,
+                        approvals[i].amount,
+                        approvals[i].operator
+                    )
+                );
+            }
+
+            // Create batch digest and sign it
+            bytes32 digest = ECDSA.toTypedDataHash(
+                pearlmit.domainSeparatorV4(),
+                keccak256(
+                    abi.encode(
+                        PearlmitHash._PERMIT_BATCH_TRANSFER_FROM_TYPEHASH,
+                        keccak256(abi.encodePacked(hashApprovals)),
+                        nonce,
+                        sigDeadline,
+                        pearlmit.masterNonce(alice),
+                        executor,
+                        hashedData
+                    )
+                )
+            );
+            (uint8 v, bytes32 r, bytes32 s) = vm.sign(aliceKey, digest);
+            bytes memory signedPermit = abi.encodePacked(r, s, v);
+
+            // Execute the permit
+            IPearlmit.PermitBatchTransferFrom memory batch = IPearlmit.PermitBatchTransferFrom({
+                approvals: approvals,
+                owner: alice,
+                nonce: nonce,
+                sigDeadline: uint48(sigDeadline),
+                signedPermit: signedPermit,
+                executor: executor,
+                hashedData: hashedData
+            });
+
+            vm.prank(bob); // Can't be called by bob
+            vm.expectRevert();
+            pearlmit.permitBatchApprove(batch, hashedData);
+
+            vm.prank(executor);
+            pearlmit.permitBatchApprove(batch, hashedData);
+        }
+        // Check the allowance
+        {
+            (uint256 allowedAmount, uint256 expiration) = pearlmit.allowance(alice, bob, 20, erc20Addr, 0);
+            assertEq(allowedAmount, 100);
+            assertEq(expiration, block.timestamp);
+        }
+
+        // Clear the allowance
+        uint256 snapshot = vm.snapshot();
+        {
+            vm.prank(bob);
+            pearlmit.clearAllowance(alice, 20, erc20Addr, 0);
+            (uint256 allowedAmount, uint256 expiration) = pearlmit.allowance(alice, bob, 20, erc20Addr, 0);
+            assertEq(allowedAmount, 0);
+            assertEq(expiration, 0);
+        }
+        vm.revertTo(snapshot);
+
+        // ERC20 transfer
+        {
+            ERC20Mock erc20 = ERC20Mock(erc20Addr);
+            vm.prank(alice);
+            erc20.approve(address(pearlmit), type(uint256).max); // Pearlmit needs to have allowance
+
+            assertEq(erc20.balanceOf(bob), 0);
+            vm.prank(bob);
+            pearlmit.transferFromERC20(alice, bob, erc20Addr, 100);
+            assertEq(erc20.balanceOf(bob), 100);
+        }
+    }
+}

--- a/test/pearlmit/PearlmitBase.t.sol
+++ b/test/pearlmit/PearlmitBase.t.sol
@@ -29,7 +29,7 @@ contract PearlmitBaseTest is TestBase, StdAssertions, StdCheats, StdUtils {
     uint256 constant INITIAL_TIMESTAMP = 1703688340;
 
     function setUp() public virtual {
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Pearlmit", "1", address(this), 0);
 
         (admin, adminKey) = makeAddrAndKey("admin");
         (alice, aliceKey) = makeAddrAndKey("alice");

--- a/test/toe/ToeToken.t.sol
+++ b/test/toe/ToeToken.t.sol
@@ -92,7 +92,7 @@ contract TapTokenTest is ToeTestHelper, BaseToeMsgType {
 
         setUpEndpoints(3, LibraryType.UltraLightNode);
 
-        pearlmit = new Pearlmit("Pearlmit", "1");
+        pearlmit = new Pearlmit("Pearlmit", "1", address(this), 0);
         cluster = ICluster(address(new Cluster(1, address(__owner))));
 
         __extExec = address(new TapiocaOmnichainExtExec());


### PR DESCRIPTION
patch(`Pearlmit`): Removed unnecessary `_afterTransferFrom` [`86dtm14xr`]
chore(`gitmodule`): `PermitC` checkout to `main` [`86dtkznra`]
patch(`Pearlmit`): Adapted to `PermitC` changes [`86dtkznra`]
patch(`Magnetar`): Adapted `Magnetar` + `modules` to `Pearlmit` changes [`86dtkznra`]
chore(`gitmodule`): `PermitC` checkout to `main` [`86dtkznra`]
patch(`Magnetar`): Fix stack too deep on `_processExerciseOption()` [`86dtm2tgr`]
patch(`Cluster`): Removed `target` in `hasRole` [`86dtm14xr`]
patch(`PearlmitHash`): Updated `TYPEHASH` [`86dtm14xr`]
patch(`PearlmitTest`): Add `test_hashBatchTransferFrom` [`86dtm14xr`]
fix(`PearlmitHash | IPearlmit`): Inconsistencies between `TYPEHASH` and `PermitBatchTransferFrom` [`86dtm14xr`]
chore(`test`): Adapted tests to `IPearlmit` change  [`86dtm14xr`]
fix(`PearlmitHash`): Missing parameter encoding in  `hashBatchTransferFrom()` [`86dtm14xr`]