### PR TITLE
Remove unused MagnetarStorage old actions IDs `CU-86dtn6486`

### DIFF
--- a/contracts/Magnetar/MagnetarStorage.sol
+++ b/contracts/Magnetar/MagnetarStorage.sol
@@ -36,17 +36,6 @@ contract MagnetarStorage is IERC721Receiver, PearlmitHandler {
 
     mapping(MagnetarModule moduleId => address moduleAddress) internal modules;
 
-    // Helpers for external usage. Not used in the contract.
-    uint8 public constant MAGNETAR_ACTION_PERMIT = 0;
-    uint8 public constant MAGNETAR_ACTION_MARKET = 2;
-    uint8 public constant MAGNETAR_ACTION_TAP_LOCK = 3;
-    uint8 public constant MAGNETAR_ACTION_TAP_UNLOCK = 4;
-    uint8 public constant MAGNETAR_ACTION_OFT = 5;
-    uint8 public constant MAGNETAR_ACTION_COLLATERAL_MODULE = 6;
-    uint8 public constant MAGNETAR_ACTION_MINT_MODULE = 7;
-    uint8 public constant MAGNETAR_ACTION_OPTION_MODULE = 8;
-    uint8 public constant MAGNETAR_ACTION_YIELDBOX_MODULE = 9;
-
     error Magnetar_NotAuthorized(address caller, address expectedCaller); // msg.send is neither the owner nor whitelisted by Cluster
     error Magnetar_ModuleNotFound(MagnetarModule module); // Module not found
     error Magnetar_UnknownReason(); // Revert reason not recognized


### PR DESCRIPTION
chore(`MagnetarStorage`): Removed unused `MAGNETAR_ACTION` constants [`86dtn6486`]