### PR TITLE
C4#120 0xadrii - Not properly tracking debt accrual `CU-86dtm99eu`

### DIFF
--- a/contracts/interfaces/bar/IBigBang.sol
+++ b/contracts/interfaces/bar/IBigBang.sol
@@ -34,7 +34,7 @@ interface IBigBang is IMarket {
 
     function getTotalDebt() external view returns (uint256);
 
-    function computeOpenInterestMintable() external returns (uint256);
+    function consumeMintableOpenInterestDebt() external returns (uint256);
 
-    function viewOpenInterest() external view returns (uint256);
+    function openInterestDebt() external view returns (uint256);
 }


### PR DESCRIPTION
patch(`IBigBang`): Adapted `openInterestDebt` related calls [`86dtm99eu`]