### PR TITLE
Add MagnetarHelper address on constructor arg in Magnetar `CU-86dtqewp7`

### DIFF
--- a/contracts/Magnetar/Magnetar.sol
+++ b/contracts/Magnetar/Magnetar.sol
@@ -16,6 +16,7 @@ import {MagnetarAction, MagnetarModule, MagnetarCall} from "tapioca-periph/inter
 import {ITapiocaOmnichainEngine, LZSendParam} from "tapioca-periph/interfaces/periph/ITapiocaOmnichainEngine.sol";
 import {ITapiocaOptionBroker} from "tapioca-periph/interfaces/tap-token/ITapiocaOptionBroker.sol";
 import {IMagnetarModuleExtender} from "tapioca-periph/interfaces/periph/IMagnetar.sol";
+import {IMagnetarHelper} from "tapioca-periph/interfaces/periph/IMagnetarHelper.sol";
 import {RevertMsgDecoder} from "tapioca-periph/libraries/RevertMsgDecoder.sol";
 import {ISingularity} from "tapioca-periph/interfaces/bar/ISingularity.sol";
 import {IYieldBox} from "tapioca-periph/interfaces/yieldbox/IYieldBox.sol";
@@ -64,12 +65,15 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
         address payable _optionModule,
         address payable _yieldBoxModule,
         IPearlmit _pearlmit,
-        address _toeHelper
+        address _toeHelper,
+        IMagnetarHelper _magnetarHelper
     ) BaseMagnetar(_cluster, _pearlmit, _toeHelper, _owner) {
         modules[MagnetarModule.CollateralModule] = _collateralModule;
         modules[MagnetarModule.MintModule] = _mintModule;
         modules[MagnetarModule.OptionModule] = _optionModule;
         modules[MagnetarModule.YieldBoxModule] = _yieldBoxModule;
+
+        helper = _magnetarHelper;
     }
 
     /// =====================
@@ -544,7 +548,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
             abi.decode(_actionCalldata[4:], (uint256, address, uint256));
 
         // compute `paymentToken` amount
-        (,uint256 _paymentTokenAmount,) =
+        (, uint256 _paymentTokenAmount,) =
             ITapiocaOptionBroker(_target).getOTCDealDetails(_oTAPTokenID, _paymentToken, _tapAmount);
         address tapToken = ITapiocaOptionBroker(_target).tapOFT();
 

--- a/test/Magnetar/Magnetar.t.sol
+++ b/test/Magnetar/Magnetar.t.sol
@@ -30,6 +30,7 @@ import {MagnetarOptionModule} from "tapioca-periph/Magnetar/modules/MagnetarOpti
 import {MagnetarMintModule} from "tapioca-periph/Magnetar/modules/MagnetarMintModule.sol";
 import {MagnetarBaseModule} from "tapioca-periph/Magnetar/modules/MagnetarBaseModule.sol";
 import {ILeverageExecutor} from "tapioca-periph/interfaces/bar/ILeverageExecutor.sol";
+import {IMagnetarHelper} from "tapioca-periph/interfaces/periph/IMagnetarHelper.sol";
 import {ITapiocaOracle} from "tapioca-periph/interfaces/periph/ITapiocaOracle.sol";
 import {ERC20WithoutStrategy} from "yieldbox/strategies/ERC20WithoutStrategy.sol";
 import {IZeroXSwapper} from "tapioca-periph/interfaces/periph/IZeroXSwapper.sol";
@@ -173,7 +174,8 @@ contract MagnetarTest is TestBase, StdAssertions, StdCheats, StdUtils, TestHelpe
             payable(optionModule),
             payable(yieldBoxModule),
             IPearlmit(address(pearlmit)),
-            address(toeHelper)
+            address(toeHelper),
+            IMagnetarHelper(address(new MagnetarHelper()))
         );
 
         utils = new MagnetarTestUtils();

--- a/test/Magnetar/modules/MagnetarTestHelper.sol
+++ b/test/Magnetar/modules/MagnetarTestHelper.sol
@@ -32,6 +32,7 @@ import {MagnetarMintModule} from "tapioca-periph/Magnetar/modules/MagnetarMintMo
 import {MagnetarBaseModule} from "tapioca-periph/Magnetar/modules/MagnetarBaseModule.sol";
 import {Magnetar} from "tapioca-periph/Magnetar/Magnetar.sol";
 
+import {IMagnetarHelper} from "tapioca-periph/interfaces/periph/IMagnetarHelper.sol";
 import {MagnetarHelper} from "tapioca-periph/Magnetar/MagnetarHelper.sol";
 import {MarketHelper} from "tapioca-bar/markets/MarketHelper.sol";
 
@@ -278,7 +279,7 @@ contract MagnetarTestHelper is TestHelper {
             address(bbMC)
         );
         setAssetOracle(penrose, bb, address(oracle));
-        
+
         assetA.setMinterStatus(address(bb), true);
         assetA.setBurnerStatus(address(bb), true);
 
@@ -435,7 +436,8 @@ contract MagnetarTestHelper is TestHelper {
             payable(setup.optionModule),
             payable(setup.yieldBoxModule),
             IPearlmit(_pearlmit),
-            address(toeHelper)
+            address(toeHelper),
+            IMagnetarHelper(address(new MagnetarHelper()))
         );
     }
 


### PR DESCRIPTION
feat(`Magnetar`): Add `_magnetarHelper` to constructor args [`86dtqewp7`]

chore: Adapted tests to latest changes [`86dtqewp7`]