### PR TITLE
Update MagnetarHelper conversion functions to include rounding parameter `CU-86dtqt272`

### DIFF
--- a/contracts/Magnetar/MagnetarHelper.sol
+++ b/contracts/Magnetar/MagnetarHelper.sol
@@ -152,28 +152,38 @@ contract MagnetarHelper {
      * @notice Return the equivalent of borrow part in asset amount.
      * @param market the Singularity or BigBang address.
      * @param borrowPart The amount of borrow part to convert.
+     * @param roundUp If true, the result is rounded up.
      * @return amount The equivalent of borrow part in asset amount.
      */
-    function getAmountForBorrowPart(IMarket market, uint256 borrowPart) external view returns (uint256 amount) {
+    function getAmountForBorrowPart(IMarket market, uint256 borrowPart, bool roundUp)
+        external
+        view
+        returns (uint256 amount)
+    {
         Rebase memory _totalBorrowed;
         (uint128 totalBorrowElastic, uint128 totalBorrowBase) = market._totalBorrow();
         _totalBorrowed = Rebase(totalBorrowElastic, totalBorrowBase);
 
-        return _totalBorrowed.toElastic(borrowPart, false);
+        return _totalBorrowed.toElastic(borrowPart, roundUp);
     }
 
     /**
      * @notice Return the equivalent of amount in borrow part.
      * @param market the Singularity or BigBang address.
      * @param amount The amount to convert.
+     * @param roundUp If true, the result is rounded up.
      * @return part The equivalent of amount in borrow part.
      */
-    function getBorrowPartForAmount(IMarket market, uint256 amount) external view returns (uint256 part) {
+    function getBorrowPartForAmount(IMarket market, uint256 amount, bool roundUp)
+        external
+        view
+        returns (uint256 part)
+    {
         Rebase memory _totalBorrowed;
         (uint128 totalBorrowElastic, uint128 totalBorrowBase) = market._totalBorrow();
         _totalBorrowed = Rebase(totalBorrowElastic, totalBorrowBase);
 
-        return _totalBorrowed.toBase(amount, false);
+        return _totalBorrowed.toBase(amount, roundUp);
     }
 
     /**

--- a/contracts/Magnetar/modules/MagnetarBaseModule.sol
+++ b/contracts/Magnetar/modules/MagnetarBaseModule.sol
@@ -53,14 +53,14 @@ abstract contract MagnetarBaseModule is MagnetarStorage {
 
         if (data.extractFromSender) {
             // do NOT allow `extractFromSender` for whitelisted addresses
-            //    because in this cases funds should be already here 
+            //    because in this cases funds should be already here
             //    since it comes from an internal flow
             if (cluster.isWhitelisted(0, msg.sender)) revert Magnetar_ExtractTokenFail();
 
-            uint256 _share  = _yb.toShare(data.assetId, data.amount, false);
+            uint256 _share = _yb.toShare(data.assetId, data.amount, false);
             _yb.transfer(msg.sender, address(this), data.assetId, _share);
         }
-        
+
         if (data.unwrap) {
             _yb.withdraw(data.assetId, address(this), address(this), data.amount, 0);
 
@@ -99,7 +99,10 @@ abstract contract MagnetarBaseModule is MagnetarStorage {
         return balanceAfter - balanceBefore;
     }
 
-    function _depositToYb(IYieldBox _yieldBox, address _user, uint256 _tokenId, uint256 _amount) internal returns (uint256 amountOut, uint256 shareOut) {
+    function _depositToYb(IYieldBox _yieldBox, address _user, uint256 _tokenId, uint256 _amount)
+        internal
+        returns (uint256 amountOut, uint256 shareOut)
+    {
         (, address assetAddress,,) = _yieldBox.assets(_tokenId);
         assetAddress.safeApprove(address(_yieldBox), _amount);
         (amountOut, shareOut) = _yieldBox.depositAsset(_tokenId, address(this), _user, _amount, 0);
@@ -111,7 +114,7 @@ abstract contract MagnetarBaseModule is MagnetarStorage {
         returns (uint256 repayed)
     {
         _market.accrue();
-        uint256 repayPart = helper.getBorrowPartForAmount(address(_market), _amount);
+        uint256 repayPart = helper.getBorrowPartForAmount(address(_market), _amount, true); // RoundUp happen in market repay
         (Module[] memory modules, bytes[] memory calls) =
             IMarketHelper(_marketHelper).repay(_from, _to, false, repayPart);
 

--- a/contracts/interfaces/periph/IMagnetarHelper.sol
+++ b/contracts/interfaces/periph/IMagnetarHelper.sol
@@ -15,9 +15,15 @@ import {ISingularity} from "tapioca-periph/interfaces/bar/ISingularity.sol";
 */
 
 interface IMagnetarHelper {
-    function getAmountForBorrowPart(address market, uint256 borrowPart) external view returns (uint256 amount);
+    function getAmountForBorrowPart(address market, uint256 borrowPart, bool roundUp)
+        external
+        view
+        returns (uint256 amount);
 
-    function getBorrowPartForAmount(address market, uint256 amount) external view returns (uint256 part);
+    function getBorrowPartForAmount(address market, uint256 amount, bool roundUp)
+        external
+        view
+        returns (uint256 part);
 
     function getFractionForAmount(ISingularity singularity, uint256 amount) external view returns (uint256 fraction);
 }


### PR DESCRIPTION
feat(`MagnetarHelper`): Add `roundUp` param to `getAmountForBorrowPart()` & `getBorrowPartForAmount()` [`86dtqt272`]

patch(`MagnetarBaseModule`): Updated `_marketRepay()` to use rounding on `MagnetarHelper` conversion [`86dtqt272`]