### PR TITLE
Fix lzCompose msg reception and toe codec `CU-86dtr19vp`

### DIFF
--- a/contracts/Magnetar/BaseMagnetar.sol
+++ b/contracts/Magnetar/BaseMagnetar.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.22;
 
 // External
 import {Ownable} from "@openzeppelin/contracts/access/Ownable.sol";
+import {Pausable} from "@openzeppelin/contracts/security/Pausable.sol";
 
 // Tapioca
 import {IMagnetarModuleExtender} from "tapioca-periph/interfaces/periph/IMagnetar.sol";
@@ -26,11 +27,12 @@ import {MagnetarStorage, IPearlmit} from "./MagnetarStorage.sol";
  * @author TapiocaDAO
  * @notice Base contract for Magnetar
  */
-contract BaseMagnetar is Ownable, MagnetarStorage {
+contract BaseMagnetar is Ownable, Pausable, MagnetarStorage {
     IMagnetarModuleExtender public magnetarModuleExtender; // For future implementations
-
+    
     error Magnetar_FailRescueEth();
     error Magnetar_EmptyAddress();
+    error Magnetar_PauserNotAuthorized();
 
     event HelperUpdate(address indexed old, address indexed newHelper);
     event ClusterUpdated(ICluster indexed oldCluster, ICluster indexed newCluster);
@@ -46,6 +48,18 @@ contract BaseMagnetar is Ownable, MagnetarStorage {
     /// =====================
     /// Owner
     /// =====================
+    /**
+     * @notice Un/Pauses this contract.
+    */
+    function setPause(bool _pauseState) external {
+        if (!cluster.hasRole(msg.sender, keccak256("PAUSABLE")) && msg.sender != owner()) revert Magnetar_PauserNotAuthorized();
+        if (_pauseState) {
+            _pause();
+        } else {
+            _unpause();
+        }
+    }
+
     /**
      * @notice updates the Cluster address.
      * @dev can only be called by the owner.

--- a/contracts/Magnetar/Magnetar.sol
+++ b/contracts/Magnetar/Magnetar.sol
@@ -51,7 +51,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
     using SafeERC20 for IERC20;
     using SafeCast for uint256;
     using SafeApprove for address;
-
+    
     error Magnetar_ValueMismatch(uint256 expected, uint256 received); // Value mismatch in the total value asked and the msg.value in burst
     error Magnetar_ActionNotValid(uint8 action, bytes actionCalldata); // Burst did not find what to execute
     error Magnetar_PearlmitTransferFailed(); // Transfer failed in pearlmit
@@ -83,7 +83,7 @@ contract Magnetar is BaseMagnetar, ERC1155Holder {
      * @notice Batch multiple calls together
      * @param calls The list of actions to perform
      */
-    function burst(MagnetarCall[] calldata calls) external payable {
+    function burst(MagnetarCall[] calldata calls) external whenNotPaused payable {
         // @dev: make sure the current magnetar is whitelisted
         _checkWhitelisted(address(this));
 

--- a/contracts/interfaces/periph/ICluster.sol
+++ b/contracts/interfaces/periph/ICluster.sol
@@ -22,4 +22,6 @@ interface ICluster {
     function lzChainId() external view returns (uint32);
 
     function hasRole(address _contract, bytes32 _role) external view returns (bool);
+
+    function setRoleForContract(address _contract, bytes32 _role, bool _hasRole) external;
 }

--- a/contracts/tapiocaOmnichainEngine/TapiocaOmnichainEngineCodec.sol
+++ b/contracts/tapiocaOmnichainEngine/TapiocaOmnichainEngineCodec.sol
@@ -583,7 +583,7 @@ library TapiocaOmnichainEngineCodec {
      * @return composeSender_ The address of the compose sender. (dst OApp).
      * @return oftComposeMsg_ The TapOFT composed message, which is the actual message.
      */
-    function decodeLzComposeMsg(bytes calldata _msg)
+    function decodeLzComposeMsg(bytes memory _msg)
         internal
         pure
         returns (address composeSender_, bytes memory oftComposeMsg_)

--- a/contracts/tapiocaOmnichainEngine/TapiocaOmnichainReceiver.sol
+++ b/contracts/tapiocaOmnichainEngine/TapiocaOmnichainReceiver.sol
@@ -94,7 +94,7 @@ abstract contract TapiocaOmnichainReceiver is BaseTapiocaOmnichainEngine, IOAppC
                 address(this), // Updated from default `toAddress`
                 _guid,
                 0, /* the index of the composed message*/
-                _message.composeMsg()
+                _message
             );
         }
 
@@ -133,7 +133,7 @@ abstract contract TapiocaOmnichainReceiver is BaseTapiocaOmnichainEngine, IOAppC
 
         // Decode LZ compose message.
         (address srcChainSender_, bytes memory oftComposeMsg_) =
-            TapiocaOmnichainEngineCodec.decodeLzComposeMsg(_message);
+            TapiocaOmnichainEngineCodec.decodeLzComposeMsg(_message.composeMsg());
         // Execute the composed message.
         _lzCompose(srcChainSender_, _guid, oftComposeMsg_);
     }

--- a/contracts/tapiocaOmnichainEngine/TapiocaOmnichainSender.sol
+++ b/contracts/tapiocaOmnichainEngine/TapiocaOmnichainSender.sol
@@ -59,7 +59,12 @@ abstract contract TapiocaOmnichainSender is BaseTapiocaOmnichainEngine {
     function sendPacket(LZSendParam calldata _lzSendParam, bytes calldata _composeMsg)
         external
         payable
-        returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
+        returns (
+            MessagingReceipt memory msgReceipt,
+            OFTReceipt memory oftReceipt,
+            bytes memory message,
+            bytes memory options
+        )
     {
         // @dev Applies the token transfers regarding this send() operation.
         // - amountDebitedLD is the amount in local decimals that was ACTUALLY debited from the sender.
@@ -72,7 +77,7 @@ abstract contract TapiocaOmnichainSender is BaseTapiocaOmnichainEngine {
         );
 
         // @dev Builds the options and OFT message to quote in the endpoint.
-        (bytes memory message, bytes memory options) = _buildOFTMsgAndOptions(
+        (message, options) = _buildOFTMsgAndOptions(
             msg.sender, _lzSendParam.sendParam, _lzSendParam.extraOptions, _composeMsg, amountToCreditLD
         );
 
@@ -92,7 +97,12 @@ abstract contract TapiocaOmnichainSender is BaseTapiocaOmnichainEngine {
     function sendPacketFrom(address _from, LZSendParam calldata _lzSendParam, bytes calldata _composeMsg)
         external
         payable
-        returns (MessagingReceipt memory msgReceipt, OFTReceipt memory oftReceipt)
+        returns (
+            MessagingReceipt memory msgReceipt,
+            OFTReceipt memory oftReceipt,
+            bytes memory message,
+            bytes memory options
+        )
     {
         if (_from == address(0)) {
             revert BaseTapiocaOmnichainEngine__ZeroAddress();
@@ -117,7 +127,7 @@ abstract contract TapiocaOmnichainSender is BaseTapiocaOmnichainEngine {
         );
 
         // @dev Builds the options and OFT message to quote in the endpoint.
-        (bytes memory message, bytes memory options) = _buildOFTMsgAndOptions(
+        (message, options) = _buildOFTMsgAndOptions(
             _from, _lzSendParam.sendParam, _lzSendParam.extraOptions, _composeMsg, amountToCreditLD
         );
 


### PR DESCRIPTION
- `TOEReceiver` : `_lzReceive` will send the whole message instead of just the composed one to  `lzCompose`
- `TOESender`: `sendPacket` & `sendPacketFrom` will now return `message` and `options`